### PR TITLE
feat: enforce auth in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,8 +16,13 @@ export function middleware(request: NextRequest) {
   if (token) {
     try {
       const authData = JSON.parse(token);
-      isAuthenticated =
-        authData.state?.isAuthenticated && authData.state?.token;
+      const authData = JSON.parse(token) as {
+        state?: { isAuthenticated?: boolean; token?: string };
+      };
+      const hasToken =
+        typeof authData?.state?.token === "string" &&
+        authData.state.token.length > 0;
+      isAuthenticated = Boolean(authData?.state?.isAuthenticated && hasToken);
     } catch {
       // Invalid token format
       isAuthenticated = false;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,43 +2,40 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {
-  // Temporarily disabled to fix hydration issues
+  // Get the pathname of the request (e.g. /, /login, /dashboard)
+  const path = request.nextUrl.pathname;
+
+  // Define paths that are considered public (accessible without authentication)
+  const isPublicPath = path === "/login";
+
+  // Get the token from the cookies or headers
+  const token = request.cookies.get("auth-storage")?.value;
+
+  // Parse the token to check if user is authenticated
+  let isAuthenticated = false;
+  if (token) {
+    try {
+      const authData = JSON.parse(token);
+      isAuthenticated =
+        authData.state?.isAuthenticated && authData.state?.token;
+    } catch {
+      // Invalid token format
+      isAuthenticated = false;
+    }
+  }
+
+  // Redirect logic
+  if (isPublicPath && isAuthenticated) {
+    // If user is authenticated and trying to access login page, redirect to home
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  if (!isPublicPath && !isAuthenticated) {
+    // If user is not authenticated and trying to access protected page, redirect to login
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
   return NextResponse.next();
-
-  // // Get the pathname of the request (e.g. /, /login, /dashboard)
-  // const path = request.nextUrl.pathname;
-
-  // // Define paths that are considered public (accessible without authentication)
-  // const isPublicPath = path === "/login";
-
-  // // Get the token from the cookies or headers
-  // const token = request.cookies.get("auth-storage")?.value;
-
-  // // Parse the token to check if user is authenticated
-  // let isAuthenticated = false;
-  // if (token) {
-  //   try {
-  //     const authData = JSON.parse(token);
-  //     isAuthenticated =
-  //       authData.state?.isAuthenticated && authData.state?.token;
-  //   } catch (error) {
-  //     // Invalid token format
-  //     isAuthenticated = false;
-  //   }
-  // }
-
-  // // Redirect logic
-  // if (isPublicPath && isAuthenticated) {
-  //   // If user is authenticated and trying to access login page, redirect to home
-  //   return NextResponse.redirect(new URL("/", request.url));
-  // }
-
-  // if (!isPublicPath && !isAuthenticated) {
-  //   // If user is not authenticated and trying to access protected page, redirect to login
-  //   return NextResponse.redirect(new URL("/login", request.url));
-  // }
-
-  // return NextResponse.next();
 }
 
 // Configure which paths the middleware should run on


### PR DESCRIPTION
## Summary
- re-enable auth guard middleware to redirect unauthorized requests

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: eslint reported errors)


------
https://chatgpt.com/codex/tasks/task_e_68a4f32a52388329b0d36a8551dfb95b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authentication-aware routing across the app.
  * Unauthenticated visitors are redirected from protected pages to the login screen.
  * Signed-in users visiting the login page are redirected to the home page.
  * Normal navigation proceeds when access is appropriate, improving access control and session flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->