### PR TITLE
refactor: centralize query client

### DIFF
--- a/src/components/providers/QueryProvider.tsx
+++ b/src/components/providers/QueryProvider.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useState, useEffect } from "react";
+import { queryClient } from "@/lib/queryClient";
 
 export default function QueryProvider({
   children,
@@ -10,27 +11,6 @@ export default function QueryProvider({
   children: React.ReactNode;
 }) {
   const [mounted, setMounted] = useState(false);
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 5 * 60 * 1000, // 5 minutes
-            gcTime: 10 * 60 * 1000, // 10 minutes
-            retry: (failureCount, error: any) => {
-              if (error?.status >= 400 && error?.status < 500) {
-                return false;
-              }
-              return failureCount < 3;
-            },
-            refetchOnWindowFocus: false,
-          },
-          mutations: {
-            retry: false,
-          },
-        },
-      })
-  );
 
   useEffect(() => {
     setMounted(true);


### PR DESCRIPTION
## Summary
- use global `queryClient` in `QueryProvider`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, React hook errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a41898ef988329b36e11136b68a16c