### PR TITLE
feat: avoid mutating user cache

### DIFF
--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -21,7 +21,8 @@ export function useUsers() {
     queryFn: () => userApi.getUsers(),
     staleTime: 2 * 60 * 1000, // 2 minutes
     select: (data) => {
-      let users = data.users;
+      // Clone the users array to avoid mutating the cached data
+      let users = [...data.users];
 
       // Apply client-side filtering
       if (userFilters.search) {
@@ -41,8 +42,8 @@ export function useUsers() {
         users = users.filter((user: any) => user.status === userFilters.status);
       }
 
-      // Apply sorting
-      users.sort((a: any, b: any) => {
+      // Apply sorting on the cloned array
+      users = [...users].sort((a: any, b: any) => {
         const aValue = a[userFilters.sortBy];
         const bValue = b[userFilters.sortBy];
 


### PR DESCRIPTION
## Summary
- clone cached users array in `useUsers` to prevent mutation
- sort cloned data rather than the cached array

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, React hook warnings, etc.)*
- `node -e "const data={users:[{name:'b'},{name:'a'}]}; let users=[...data.users]; users=[...users].sort((a,b)=>a.name.localeCompare(b.name)); console.log('sorted',users); console.log('original',data.users);"`


------
https://chatgpt.com/codex/tasks/task_e_68a4f3220cfc8329ad3fbc0c741e98fc