### PR TITLE
Require JWT_SECRET env variable for auth routes

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -3,7 +3,10 @@ import prisma from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 
-const SECRET_KEY = process.env.JWT_SECRET || "your_secret_key";
+const SECRET_KEY = process.env.JWT_SECRET;
+if (!SECRET_KEY) {
+    throw new Error("JWT_SECRET environment variable is not set");
+}
 
 export async function POST(req: NextRequest) {
     const { email, password } = await req.json();

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -3,7 +3,10 @@ import prisma from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 
-const SECRET_KEY = process.env.JWT_SECRET || "your_secret_key";
+const SECRET_KEY = process.env.JWT_SECRET;
+if (!SECRET_KEY) {
+  throw new Error("JWT_SECRET environment variable is not set");
+}
 
 export async function POST(req: NextRequest) {
   try {


### PR DESCRIPTION
## Summary
- enforce presence of JWT_SECRET for login route
- enforce presence of JWT_SECRET for register route

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint reported many errors)


------
https://chatgpt.com/codex/tasks/task_e_68a4189f16a88329a7e954150c7d375e