### PR TITLE
Validate Together API configuration and error handling

### DIFF
--- a/src/lib/together.ts
+++ b/src/lib/together.ts
@@ -1,25 +1,68 @@
-export async function generateStory(prompt: string) {
-    const response = await fetch(process.env.TOGETHER_API_URL!, {
-        method: "POST",
-        headers: {
-            Authorization: `Bearer ${process.env.TOGETHER_API_KEY}`,
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-            model: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free",
-            messages: [
-                {
-                    role: "user",
-                    content: prompt,
-                },
-            ],
-        }),
-    });
+interface TogetherAPIMessage {
+    content?: string;
+}
 
-    if (!response.ok) {
-        throw new Error(`Together API error: ${response.statusText}`);
+interface TogetherAPIChoice {
+    message?: TogetherAPIMessage;
+}
+
+interface TogetherAPIResponse {
+    choices?: TogetherAPIChoice[];
+}
+
+export async function generateStory(prompt: string) {
+    const apiUrl = process.env.TOGETHER_API_URL;
+    const apiKey = process.env.TOGETHER_API_KEY;
+
+    if (!apiUrl) {
+        throw new Error("Missing TOGETHER_API_URL environment variable");
     }
 
-    const data = await response.json();
+    if (!apiKey) {
+        throw new Error("Missing TOGETHER_API_KEY environment variable");
+    }
+
+    let response: Response;
+
+    try {
+        response = await fetch(apiUrl, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                model: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free",
+                messages: [
+                    {
+                        role: "user",
+                        content: prompt,
+                    },
+                ],
+            }),
+        });
+    } catch (error) {
+        throw new Error(
+            `Network error while calling Together API: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
+
+    if (!response.ok) {
+        throw new Error(`Together API error: ${response.status} ${response.statusText}`);
+    }
+
+    let data: TogetherAPIResponse;
+    try {
+        data = (await response.json()) as TogetherAPIResponse;
+    } catch (error) {
+        throw new Error(
+            `Error parsing Together API response: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
+
     return data.choices?.[0]?.message?.content || "No content generated.";
 }


### PR DESCRIPTION
## Summary
- validate `TOGETHER_API_URL` and `TOGETHER_API_KEY` env vars
- add network and JSON parse error handling for Together API calls
- define interfaces for typed Together API responses

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: multiple lint errors across repository)


------
https://chatgpt.com/codex/tasks/task_e_68a4189d62048329888fca267890d9cb