### PR TITLE
chore: guard development logs

### DIFF
--- a/src/app/api/forgot-password/route.ts
+++ b/src/app/api/forgot-password/route.ts
@@ -57,9 +57,11 @@ export async function POST(req: NextRequest) {
       process.env.NEXTAUTH_URL || "http://localhost:3001"
     }/reset-password?token=${resetToken}&email=${email}`;
 
-    console.log("🔗 Reset Password Link:", resetLink);
-    console.log("📧 Email:", email);
-    console.log("🔑 Token:", resetToken);
+    if (process.env.NODE_ENV === "development") {
+      console.log("🔗 Reset Password Link:", resetLink);
+      console.log("📧 Email:", email);
+      console.log("🔑 Token:", resetToken);
+    }
 
     // 6. Return success message
     return NextResponse.json({

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -139,7 +139,7 @@ export function useForgotPassword() {
       toast.success(data.message);
 
       // In development, show reset link
-      if (data.resetLink) {
+      if (data.resetLink && process.env.NODE_ENV === "development") {
         console.log("🔗 Reset link:", data.resetLink);
         toast.info("Check console for reset link (dev only)");
       }


### PR DESCRIPTION
## Summary
- wrap forgot password API logging with NODE_ENV check
- guard useAuth forgot password reset link logging for development only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any & React Hook errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f321aeb4832985923a165d2f93b9