### PR TITLE
refactor: use env for admin password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ADMIN_PASSWORD=changeme

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,12 +1,16 @@
 import { PrismaClient } from "@prisma/client";
 import bcrypt from "bcryptjs";
+import "dotenv/config";
 
 const prisma = new PrismaClient();
 
 async function main() {
   // Tạo tài khoản admin mẫu
-  const password = "123456"; // Mật khẩu plaintext
-  const hashedPassword = await bcrypt.hash(password, 10); // Hash
+  const adminPassword = process.env.ADMIN_PASSWORD;
+  if (!adminPassword) {
+    throw new Error("ADMIN_PASSWORD environment variable is not set");
+  }
+  const hashedPassword = await bcrypt.hash(adminPassword, 10);
 
   // Kiểm tra user đã tồn tại chưa
   const email = "admin@example.com";

--- a/prisma/seeders/user.ts
+++ b/prisma/seeders/user.ts
@@ -1,10 +1,15 @@
 import { PrismaClient } from "@prisma/client";
 import bcrypt from "bcryptjs";
+import "dotenv/config";
 
 const prisma = new PrismaClient();
 
 export async function seedUsers() {
-  const password = await bcrypt.hash("123456", 10);
+  const adminPassword = process.env.ADMIN_PASSWORD;
+  if (!adminPassword) {
+    throw new Error("ADMIN_PASSWORD environment variable is not set");
+  }
+  const password = await bcrypt.hash(adminPassword, 10);
 
   const users = [
     {


### PR DESCRIPTION
## Summary
- use ADMIN_PASSWORD environment variable when seeding admin
- add example .env file for ADMIN_PASSWORD

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react/no-unescaped-entities and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a525f5c33c832993ce2b464a3774d3