### PR TITLE
Refactor story features to use typed hooks

### DIFF
--- a/src/components/story/StoryFormOptimized.tsx
+++ b/src/components/story/StoryFormOptimized.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useStories, useCreateStory } from "@/hooks/useStories";
+import type { Story } from "@/types/story";
 import { Loader2, RefreshCw } from "lucide-react";
 
 export default function StoryFormOptimized() {
@@ -28,7 +29,7 @@ export default function StoryFormOptimized() {
       } else {
         setCurrentStory("Không tạo được nội dung.");
       }
-    } catch (error) {
+    } catch {
       setCurrentStory("Đã xảy ra lỗi khi tạo truyện.");
     }
   }
@@ -106,7 +107,7 @@ export default function StoryFormOptimized() {
           </div>
         ) : (
           <ul className="space-y-4">
-            {stories.map((story: any) => (
+            {stories.map((story: Story) => (
               <li
                 key={story.id}
                 className="p-4 border rounded-lg bg-white shadow-sm hover:shadow-md transition-shadow"
@@ -114,7 +115,7 @@ export default function StoryFormOptimized() {
                 <div className="flex justify-between items-start mb-2">
                   <p className="text-sm text-gray-600 font-medium">
                     Prompt:{" "}
-                    <span className="italic font-normal">"{story.prompt}"</span>
+                    <span className="italic font-normal">&quot;{story.prompt}&quot;</span>
                   </p>
                   <p className="text-xs text-gray-400 whitespace-nowrap ml-4">
                     {new Date(story.createdAt).toLocaleString("vi-VN")}

--- a/src/hooks/useStories.ts
+++ b/src/hooks/useStories.ts
@@ -1,29 +1,19 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { apiRequest } from "@/lib/api";
+import type { Story } from "@/types/story";
 
 // API functions
 const storyApi = {
   getStories: async () => {
-    const res = await fetch("/api/stories");
-    if (!res.ok) {
-      throw new Error(`HTTP error! status: ${res.status}`);
-    }
-    const data = await res.json();
-    return Array.isArray(data) ? data : [];
+    return apiRequest<Story[]>("/api/stories");
   },
 
   createStory: async (prompt: string) => {
-    const res = await fetch("/api/story", {
+    return apiRequest<Story>("/api/story", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ prompt }),
     });
-
-    if (!res.ok) {
-      throw new Error(`HTTP error! status: ${res.status}`);
-    }
-
-    return res.json();
   },
 };
 
@@ -35,7 +25,7 @@ export const storyKeys = {
 
 // Get stories hook
 export function useStories() {
-  return useQuery({
+  return useQuery<Story[]>({
     queryKey: storyKeys.lists(),
     queryFn: storyApi.getStories,
     staleTime: 2 * 60 * 1000, // 2 minutes
@@ -59,7 +49,7 @@ export function useCreateStory() {
         toast.error("Không tạo được nội dung truyện");
       }
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       console.error("Create story failed:", error);
       toast.error("Đã xảy ra lỗi khi tạo truyện");
     },

--- a/src/services/storyService.ts
+++ b/src/services/storyService.ts
@@ -1,22 +1,38 @@
-import {generateStory} from "@/lib/together";
+import { generateStory } from "@/lib/together";
 import prisma from "@/lib/prisma";
+import type { Story } from "@/types/story";
 
-
-export async function createAndSaveStory(prompt: string) {
-    const content = await generateStory(prompt);
-
-    const story = await prisma.story.create({
-        data: {
-            prompt,
-            content,
-        },
-    });
-
-    return story;
+export async function createAndSaveStory(prompt: string): Promise<Story> {
+    try {
+        const content = await generateStory(prompt);
+        const story = await prisma.story.create({
+            data: { prompt, content },
+        });
+        return {
+            id: story.id,
+            prompt: story.prompt,
+            content: story.content,
+            createdAt: story.createdAt.toISOString(),
+        };
+    } catch (error) {
+        console.error("Error creating story:", error);
+        throw error;
+    }
 }
 
-export async function getStories() {
-    return prisma.story.findMany({
-        orderBy: { createdAt: "desc" },
-    });
+export async function getStories(): Promise<Story[]> {
+    try {
+        const stories = await prisma.story.findMany({
+            orderBy: { createdAt: "desc" },
+        });
+        return stories.map((s) => ({
+            id: s.id,
+            prompt: s.prompt,
+            content: s.content,
+            createdAt: s.createdAt.toISOString(),
+        }));
+    } catch (error) {
+        console.error("Error fetching stories:", error);
+        throw error;
+    }
 }

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -1,0 +1,7 @@
+// types/story.ts
+export interface Story {
+    id: string;
+    prompt: string;
+    content: string;
+    createdAt: string; // ISO timestamp
+}


### PR DESCRIPTION
## Summary
- add dedicated `Story` interface
- wrap story service methods with error handling and typed results
- use shared `apiRequest` and hooks across story forms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a525f1fd9883298b5303e3dc710f3a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * History now shows full story content and displays prompts with proper quotes.
  * Dates in history are formatted in your locale (vi-VN).
  * “Làm mới” refreshes the history list instantly.

* Bug Fixes
  * Displays an error message if story generation fails.

* Refactor
  * Migrated to hook-based data fetching and centralized API handling for more reliable loading states and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->