### PR TITLE
chore: disable allowJs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- remove `allowJs` from TypeScript configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: 142 problems)*
- `npx tsc --noEmit` *(fails: property does not exist errors in stories)*

------
https://chatgpt.com/codex/tasks/task_e_68a525f47ad08329ba177007df10ddfc