### PR TITLE
feat: add basic chat interface with Zustand

### DIFF
--- a/src/app/chat/new-group/page.tsx
+++ b/src/app/chat/new-group/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useChatStore } from "@/store";
+
+export default function NewGroupPage() {
+  const [name, setName] = useState("");
+  const addConversation = useChatStore((s) => s.addConversation);
+  const router = useRouter();
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    addConversation(name.trim());
+    setName("");
+    router.push("/chat");
+  };
+
+  return (
+    <div className="p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Group name"
+        />
+        <Button type="submit">Create Group</Button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ConversationList } from "./ConversationList";
+import { MessageList } from "./MessageList";
+import { MessageInput } from "./MessageInput";
+
+export function ChatWindow() {
+  return (
+    <div className="flex h-full border rounded-lg overflow-hidden">
+      <aside className="w-64 border-r">
+        <ConversationList />
+      </aside>
+      <section className="flex flex-1 flex-col">
+        <MessageList />
+        <MessageInput />
+      </section>
+    </div>
+  );
+}

--- a/src/components/chat/ConversationList.tsx
+++ b/src/components/chat/ConversationList.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useChatStore } from "@/store";
+import { cn } from "@/lib/utils";
+
+export function ConversationList() {
+  const conversations = useChatStore((s) => s.conversations);
+  const currentId = useChatStore((s) => s.currentConversationId);
+  const setCurrentConversation = useChatStore((s) => s.setCurrentConversation);
+
+  if (conversations.length === 0) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">No conversations</div>
+    );
+  }
+
+  return (
+    <ul className="divide-y">
+      {conversations.map((conv) => (
+        <li
+          key={conv.id}
+          onClick={() => setCurrentConversation(conv.id)}
+          className={cn(
+            "p-4 cursor-pointer hover:bg-accent",
+            currentId === conv.id && "bg-accent"
+          )}
+        >
+          {conv.name}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { FormEvent } from "react";
+import { useChatStore } from "@/store";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function MessageInput() {
+  const draft = useChatStore((s) => s.draftMessage);
+  const setDraft = useChatStore((s) => s.setDraftMessage);
+  const sendMessage = useChatStore((s) => s.sendMessage);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!draft.trim()) return;
+    sendMessage(draft.trim());
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 border-t flex gap-2">
+      <Input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        placeholder="Type a message"
+        className="flex-1"
+      />
+      <Button type="submit">Send</Button>
+    </form>
+  );
+}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useChatStore } from "@/store";
+
+export function MessageList() {
+  const currentId = useChatStore((s) => s.currentConversationId);
+  const conversations = useChatStore((s) => s.conversations);
+
+  const messages =
+    conversations.find((c) => c.id === currentId)?.messages ?? [];
+
+  return (
+    <div className="flex-1 p-4 space-y-2 overflow-y-auto">
+      {messages.map((msg) => (
+        <div key={msg.id} className="p-2 rounded bg-secondary">
+          <div className="text-xs text-muted-foreground mb-1">
+            {msg.sender}
+          </div>
+          <div>{msg.content}</div>
+        </div>
+      ))}
+      {messages.length === 0 && (
+        <p className="text-sm text-muted-foreground">No messages</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/index.ts
+++ b/src/components/chat/index.ts
@@ -1,0 +1,4 @@
+export { ChatWindow } from "./ChatWindow";
+export { ConversationList } from "./ConversationList";
+export { MessageList } from "./MessageList";
+export { MessageInput } from "./MessageInput";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,3 +31,4 @@ export { StatusBar } from "./StatusBar";
 export { StoreHydration } from "./StoreHydration";
 export { ThemeProvider } from "./theme-provider";
 export { UsersList } from "./UsersList";
+export * from "./chat";

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -1,0 +1,59 @@
+import { create } from "zustand";
+
+interface Message {
+  id: string;
+  content: string;
+  sender: string;
+  timestamp: number;
+}
+
+interface Conversation {
+  id: string;
+  name: string;
+  messages: Message[];
+}
+
+interface ChatState {
+  conversations: Conversation[];
+  currentConversationId: string | null;
+  draftMessage: string;
+  setDraftMessage: (value: string) => void;
+  addConversation: (name: string) => void;
+  setCurrentConversation: (id: string) => void;
+  sendMessage: (content: string, sender?: string) => void;
+}
+
+function generateId() {
+  return Math.random().toString(36).slice(2, 9);
+}
+
+export const useChatStore = create<ChatState>((set, get) => ({
+  conversations: [],
+  currentConversationId: null,
+  draftMessage: "",
+  setDraftMessage: (value) => set({ draftMessage: value }),
+  addConversation: (name) =>
+    set((state) => ({
+      conversations: [
+        ...state.conversations,
+        { id: generateId(), name, messages: [] },
+      ],
+    })),
+  setCurrentConversation: (id) => set({ currentConversationId: id }),
+  sendMessage: (content, sender = "You") => {
+    const id = get().currentConversationId;
+    if (!id) return;
+    const message: Message = {
+      id: generateId(),
+      content,
+      sender,
+      timestamp: Date.now(),
+    };
+    set((state) => ({
+      conversations: state.conversations.map((conv) =>
+        conv.id === id ? { ...conv, messages: [...conv.messages, message] } : conv
+      ),
+      draftMessage: "",
+    }));
+  },
+}));

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,3 +5,4 @@ export { useUIStore } from "./uiStore";
 
 // Re-export types for convenience
 export type { AuthUser, User as AdminUser, PublicUser } from "@/types/user";
+export { useChatStore } from "./chatStore";


### PR DESCRIPTION
## Summary
- implement chat store using Zustand for conversation state
- add chat UI components with Radix UI and Tailwind
- introduce chat page and new group creation page

## Testing
- `npm test` (fails: 23 failed, 20 passed)
- `npm run lint` (fails: Unexpected any, missing display name, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68ba38ce42208329903c8ed706d2566f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new Chat experience with a two-pane layout: conversations on the left, messages on the right.
  - Added a “Create Group” page to start new chat groups with simple name validation.
  - Enabled composing and sending messages; drafts clear automatically after sending.
  - Seamless switching between conversations with visual selection.
  - Helpful empty states when there are no conversations or messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->