### PR TITLE
Add speech synthesis click-to-speak component

### DIFF
--- a/src/components/story/AdvancedStoryForm.tsx
+++ b/src/components/story/AdvancedStoryForm.tsx
@@ -32,6 +32,7 @@ import AdvancedOptionsConfig from "./AdvancedOptionsConfig";
 import StoryConfigSummary from "./StoryConfigSummary";
 import TemplateCard from "./TemplateCard";
 import PreferencesStatus from "./PreferencesStatus";
+import ClickToSpeak from "./ClickToSpeak";
 
 export default function AdvancedStoryForm() {
   const [prompt, setPrompt] = useState("");
@@ -694,7 +695,7 @@ export default function AdvancedStoryForm() {
               </h3>
             </div>
             <div className="whitespace-pre-line text-gray-800 leading-relaxed bg-white p-4 rounded-lg shadow-sm border border-green-100">
-              {story}
+              <ClickToSpeak text={story} />
             </div>
           </div>
         )}

--- a/src/components/story/ClickToSpeak.tsx
+++ b/src/components/story/ClickToSpeak.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface ClickToSpeakProps {
+  text: string;
+}
+
+const VIETNAMESE_DIACRITIC_REGEX = /[\u00E0-\u00E3\u1EA1\u1EA3\u00E2\u1EA5\u1EA7\u1EAD\u1EA9\u1EAB\u0103\u1EAF\u1EB1\u1EB7\u1EB3\u1EB5\u00E8-\u00EB\u1EB9\u1EBB\u00EA\u1EBF\u1EC1\u1EC7\u1EC3\u1EC5\u00EC-\u00EF\u1EC9\u0129\u00F2-\u00F5\u1ECD\u1ECF\u00F4\u1ED1\u1ED3\u1ED9\u1ED5\u1ED7\u01A1\u1EDB\u1EDD\u1EE3\u1EDF\u1EE1\u00F9-\u00FB\u1EE5\u1EE7\u01B0\u1EEB\u1EED\u1EF1\u1EEF\u1EF3-\u1EF9\u0111]/i;
+
+function hasVietnameseDiacritics(word: string) {
+  return VIETNAMESE_DIACRITIC_REGEX.test(word);
+}
+
+export default function ClickToSpeak({ text }: ClickToSpeakProps) {
+  const [supported, setSupported] = useState(true);
+  const [rate, setRate] = useState(1);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const tokens = text.split(/(\s+)/);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+      setSupported(false);
+    }
+  }, []);
+
+  const speakWord = (word: string) => {
+    if (!supported) return;
+    const utterance = new SpeechSynthesisUtterance(word);
+    utterance.lang = hasVietnameseDiacritics(word) ? "vi-VN" : "en-US";
+    utterance.rate = rate;
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(utterance);
+  };
+
+  const playAll = () => {
+    if (!supported) return;
+    window.speechSynthesis.cancel();
+    setIsPlaying(true);
+    const utterances = tokens
+      .filter((w) => w.trim())
+      .map((w) => {
+        const u = new SpeechSynthesisUtterance(w);
+        u.lang = hasVietnameseDiacritics(w) ? "vi-VN" : "en-US";
+        u.rate = rate;
+        return u;
+      });
+    if (utterances.length > 0) {
+      utterances[utterances.length - 1].onend = () => setIsPlaying(false);
+    } else {
+      setIsPlaying(false);
+    }
+    utterances.forEach((u) => window.speechSynthesis.speak(u));
+  };
+
+  const stop = () => {
+    if (!supported) return;
+    window.speechSynthesis.cancel();
+    setIsPlaying(false);
+  };
+
+  if (!supported) {
+    return (
+      <>
+        {text}
+        <p className="mt-2 text-sm text-gray-500">
+          ⚠️ Trình duyệt của bạn không hỗ trợ Web Speech API.
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="mb-2 flex items-center gap-2 text-sm">
+        <button
+          type="button"
+          onClick={playAll}
+          disabled={isPlaying}
+          className="rounded bg-blue-600 px-2 py-1 text-white disabled:bg-gray-400"
+        >
+          Play all
+        </button>
+        <button
+          type="button"
+          onClick={stop}
+          className="rounded bg-red-600 px-2 py-1 text-white"
+        >
+          Stop
+        </button>
+        <label className="flex items-center gap-1">
+          Speed:
+          <select
+            value={rate}
+            onChange={(e) => setRate(parseFloat(e.target.value))}
+            className="rounded border px-1 py-0.5"
+          >
+            <option value="0.75">0.75x</option>
+            <option value="1">1x</option>
+            <option value="1.25">1.25x</option>
+            <option value="1.5">1.5x</option>
+            <option value="2">2x</option>
+          </select>
+        </label>
+      </div>
+      <div className="whitespace-pre-line">
+        {tokens.map((token, i) =>
+          token.trim() === "" ? (
+            token
+          ) : (
+            <span
+              key={i}
+              onClick={() => speakWord(token.replace(/[.,!?;:'"()]/g, ""))}
+              className="cursor-pointer hover:bg-yellow-100"
+            >
+              {token}
+            </span>
+          )
+        )}
+      </div>
+    </>
+  );
+}
+

--- a/src/components/story/StoryForm.tsx
+++ b/src/components/story/StoryForm.tsx
@@ -5,6 +5,7 @@ import StoryLoadingStages from "./StoryLoadingStages";
 import MagicalLoader from "./MagicalLoader";
 import SmartProgressLoader from "./SmartProgressLoader";
 import InteractiveLoader from "./InteractiveLoader";
+import ClickToSpeak from "./ClickToSpeak";
 
 export default function StoryForm() {
   const [prompt, setPrompt] = useState("Tạo giúp tôi 1 truyện chêm về IT");
@@ -239,7 +240,7 @@ export default function StoryForm() {
               </h3>
             </div>
             <div className="whitespace-pre-line text-gray-800 leading-relaxed bg-white p-4 rounded-lg shadow-sm border border-green-100">
-              {story}
+              <ClickToSpeak text={story} />
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- add ClickToSpeak component for per-word speech playback with diacritic detection
- integrate ClickToSpeak into StoryForm and AdvancedStoryForm

## Testing
- `npm test` *(fails: jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68be494f39d883298045af406e2e2113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text-to-speech for generated stories with Play All, Stop, and speed control.
  * Tap individual words to hear pronunciation; auto-detects language per word (supports Vietnamese diacritics).
  * Integrated into story creation flows: generated stories now appear with speech controls instead of plain text.
  * Graceful fallback: shows normal text with a notice if the browser doesn’t support speech.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->